### PR TITLE
Fix MSVC build for 4.07-4.09

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -58,8 +58,17 @@ let modules_post_4_02 =
   ]
 
 let missing_modules =
-  List.filter modules_post_4_02 ~f:(fun (_, v) -> version < v)
-  |> List.map ~f:fst
+  let missing =
+    List.filter modules_post_4_02 ~f:(fun (_, v) -> version < v)
+    |> List.map ~f:fst
+  in
+    (* For OCaml 4.07-4.09 incl. this solves the problem of being unable to
+       generate empty .cmxa files on MSVC by duplicating the Pervasives module
+       (and updating its deprecation warning not to refer to this library! *)
+    if version < (4, 10) && version >= (4, 7) then
+      "Pervasives"::missing
+    else
+      missing
 
 let all_modules_except_stdlib =
   (modules_in_4_02 @ List.map modules_post_4_02 ~f:fst)

--- a/src/pervasives.ml
+++ b/src/pervasives.ml
@@ -1,0 +1,5 @@
+[@@@ocaml.deprecated "Use Stdlib instead."]
+
+[@@@ocaml.warning "-3"]
+
+include Stdlib.Pervasives


### PR DESCRIPTION
This should fix #11. Although with the library will be build with https://github.com/ocaml/dune/pull/2693, OCaml 4.07-4.09 can't use the resulting `stdlib_shims.cmxa` file without https://github.com/ocaml/ocaml/pull/9011 which will require at least OCaml 4.10.0, so a workaround is needed here too.

The workaround I've attempted is to duplicate the `Pervasives` module. This has the immediate effect of allowing the deprecation warning from 4.08.0 to be changed so that the stdlib-shims library is not recursively mentioned. On OCaml 4.07 this has no effect (cf. https://github.com/ocaml/ocaml/pull/2041 in 4.08.0), so OCaml 4.07.0 doesn't *gain* the deprecation warning.

The purpose of this library is to provide compatibility with `Stdlib` for OCaml < 4.07.0. In those versions, it's virtually possible to define a module called `Pervasives` (that's the purpose of https://github.com/ocaml/ocaml/pull/1010), so if a user uses `stdlib-shims` then they have already opted out of being able to shadow standard library modules, and the inclusion of our own `pervasives.cmi` is - I think - safe. It's also the case that if you're using this library, you're meant to be avoiding using `Pervasives` completely.