### PR TITLE
Added fix for msvc also for 4.11

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -53,8 +53,8 @@ let modules_in_4_02 =
 let missing_modules =
   if version < (4, 07) then
     ["Stdlib"]
-  else if version < (4, 11) then
-    (* For OCaml 4.07-4.10 incl. this solves the problem of being unable to
+  else if version < (4, 12) then
+    (* For OCaml 4.07-4.11 incl. this solves the problem of being unable to
        generate empty .cmxa files on MSVC by duplicating the Pervasives module
        (and updating its deprecation warning not to refer to this library! *)
     ["Pervasives"]


### PR DESCRIPTION
As explained in issue #15 the fix might be needed for more OCaml
versions. This also includes adding the fix for 4.11.

This seems to fix at least my problems with a non-existing stdlib.lib with OCaml 4.11.1.